### PR TITLE
Fix LaTeX reference rendering and improve popup styling

### DIFF
--- a/main.js
+++ b/main.js
@@ -273,6 +273,10 @@ function sanitizeLaTeX(text, asMath=false) {
     .replace(/\\begin\{theorem\}|\\end\{theorem\}/g, '')
     .replace(/\\begin\{lemma\}|\\end\{lemma\}/g, '')
     .replace(/\\begin\{definition\}|\\end\{definition\}/g, '')
+    // remove list environments that MathJax can't render well
+    .replace(/\\begin\{(?:enumerate|itemize)\*?\}/g, '')
+    .replace(/\\end\{(?:enumerate|itemize)\*?\}/g, '')
+    .replace(/\\item\s*/g, '\u2022 ')
     // common typos such as \beign{enumerate}
     .replace(/\\beign\s*\{/g, '\\begin{');
 
@@ -281,8 +285,8 @@ function sanitizeLaTeX(text, asMath=false) {
     .replace(/\$(\\(?:eq)?ref\{[^}]+\})\$/g, '$1')
     .replace(/\\\((\\(?:eq)?ref\{[^}]+\})\\\)/g, '$1')
     .replace(/\\\[(\\(?:eq)?ref\{[^}]+\})\\\]/g, '$1')
-    .replace(/\\eqref\{([^}]+)\}/g, '\\eqref{$1}')
-    .replace(/\\ref\{([^}]+)\}/g, '\\ref{$1}');
+    .replace(/\\(C?ref|eqref)\{([^}]+)\}/g,
+      (_, cmd, lbl) => `\\text{\\textbackslash ${cmd}\{${lbl}\}}`);
 
   out = out.trim();
   if (asMath && !/[\$\\begin\[]/.test(out)) {

--- a/style.css
+++ b/style.css
@@ -89,6 +89,7 @@ html, body {
   border: 1px solid #ccc;
   border-top: none;
   padding: 8px;
+  line-height: 1.4;
   white-space: pre-wrap;
   max-height: 300px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- handle `\ref`/`\eqref` commands so unresolved references show as text
- ignore list environments and render `\item` entries as bullets
- space out lines in popup sections for better readability

## Testing
- `node test_load.js`
- `node test_render.js`
